### PR TITLE
Feat(SubmitPromise): Sticky footer for every page, changed year in footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,17 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/static/favicon-16x16.png">
     <link rel="shortcut icon" href="/static/favicon.ico">
     <title>OpenPromises</title>
+    <style>
+    html, body {
+      height: 100%;
+      overflow-y: hidden;
+    }
+    #app {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+    }
+    </style>
   </head>
   <body>
     <div id="app"></div>

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -23,7 +23,7 @@
         </el-row>
         <el-row class="copyright">
           <el-col >
-            © 2019 OpenPromises
+            © 2020 OpenPromises
           </el-col>
         </el-row>
     </footer>
@@ -54,7 +54,7 @@ export default {
   margin-top: 20px;
   background-color: darkslategray;
   padding: 10px 5px;
-  color: white
+  color: white;
 }
 .footer-link {
   color: white;

--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -86,6 +86,7 @@
             <p>What we are building behind the scenes is a platform that can be deployed for any country. If you are interested to bring this to your country, please <a href="https://facebook.com/openpromises.malaysia" target="_blank">message us on facebook</a></p>
           </el-card>
         </el-col>
+        <!--
         <el-col :md="24">
           <el-card>
             <h2>The Team</h2>
@@ -104,6 +105,7 @@
             <p>None of us are affiliated with any political party. We are just ordinary citizens hoping to do our small part in improving our country’s democracy.</p>
           </el-card>
         </el-col>
+        -->
       </el-row>
     </div>
   </main>

--- a/src/views/SubmitPromise.vue
+++ b/src/views/SubmitPromise.vue
@@ -196,6 +196,10 @@ export default {
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped>
+.about {
+  height: 90%;
+}
+
 .about-points {
   max-width: 600px;
   margin: 0 auto;


### PR DESCRIPTION
feature or bug? : Feature
changes to user:

- Main part of the web page is scrollable and not the entire web page.

- Copyright year in the footer is changed from 2019 to 2020.

under the hood changes:

- Modified CSS properties in index.html and SubmitPromise.vue. The div container with id="app" is scrollable, and not the entire web page.

- Modified year (from 2019 to 2020) after &copy in Footer.vue
