### PR TITLE
feat(App): Sticky footer, modified year in footer

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -33,6 +33,7 @@ export default {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   color: #2c3e50;
+  min-height: calc(97.5vh);
 }
 
 .el-main {

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -23,7 +23,7 @@
         </el-row>
         <el-row class="copyright">
           <el-col >
-            © 2019 OpenPromises
+            © 2020 OpenPromises
           </el-col>
         </el-row>
     </footer>


### PR DESCRIPTION
feature or bug? : Feature
changes to user:
- Footer sticky to bottom of page, including /submit page.
- Year in the footer is modified from 2019 to 2020.

under the hood changes:
- Added  `min-height: calc(97.5vh);` property in `App.vue`
- Modified `<el-row class="copyright">` in `footer.vue`