### PR TITLE
feat(views/Promise): link to politician

### DIFF
--- a/app/src/components/Promise/Desktop.vue
+++ b/app/src/components/Promise/Desktop.vue
@@ -12,7 +12,9 @@
 
       <el-card class="hero" :style="'background-color:' + bgColor">
         <span class="status">{{ promise.status }}</span>
-        <p class="card-title">{{ politician.name }}</p>
+        <router-link :to="/politician/ + politician.id">
+          <p class="card-title">{{ politician.name }}</p>
+        </router-link>
         <h1>{{ promise.title }}</h1>
         <p class="Promise_Mobile_date">{{ formatDate(promise.source_date) }}</p>
       </el-card>
@@ -162,5 +164,9 @@ export default {
   width: 50%;
   text-align: center;
   border-radius: 5%
+}
+
+a {
+  text-decoration: none;
 }
 </style>

--- a/app/src/views/Politicians.vue
+++ b/app/src/views/Politicians.vue
@@ -136,6 +136,7 @@ main {
 
 a {
   text-decoration: none;
+  color: unset;
 }
 
 .bottom {


### PR DESCRIPTION
feature or bug? : feature
changes to user:

- on the promise page, I can now click on the politician's name to go to the politician's page

closes #275 
