### PR TITLE
Improve hero and card visuals

### DIFF
--- a/src/components/Hero.vue
+++ b/src/components/Hero.vue
@@ -42,7 +42,7 @@ export default {
 }
 
 #tagline {
-  font-size: 24px;
+  font-size: 32px;
 }
 
 .hero-copy {
@@ -54,6 +54,7 @@ export default {
   justify-content: space-around;
   align-items: center;
   flex-wrap: wrap;
+  margin: 20px 0;
 }
 
 #description {

--- a/src/components/PoliticianCard.vue
+++ b/src/components/PoliticianCard.vue
@@ -63,10 +63,12 @@ export default {
   height: 120px;
   margin: 5px;
   box-shadow: 2px 2px 5px rgba(0,0,0,0.25);
+  transition: box-shadow 0.3s ease, background-color 0.3s ease;
 }
 
 .el-card:hover {
   background-color: rgba(240, 248, 255, 0.5);
+  box-shadow: 4px 4px 8px rgba(0,0,0,0.35);
 }
 .card-body {
   display: flex;

--- a/src/views/ViewByState.vue
+++ b/src/views/ViewByState.vue
@@ -3,7 +3,7 @@
     <el-row id="main_info">
           <section id="page-title">
               <h1>Promises relating to {{ stateName }}</h1>
-              <img class="state-image" :src=stateObject.image>
+              <img class="state-image" :src="stateObject.image" :alt="stateName + ' image'">
           </section>
           <section>
               <loading-spinner v-if="appStatus === 'loading'" />


### PR DESCRIPTION
## Summary
- enlarge hero tagline size and add margin
- smooth politician card hover effect
- add alt text to state image for accessibility

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6843b22415c88329a28526f9949c9d49